### PR TITLE
feature/ChainNavigation

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v7.1.3"
-github "Quick/Quick" "v1.3.1"
+github "Quick/Nimble" "v7.3.1"
+github "Quick/Quick" "v1.3.2"

--- a/Direkt.xcodeproj/project.pbxproj
+++ b/Direkt.xcodeproj/project.pbxproj
@@ -190,10 +190,11 @@
 				TargetAttributes = {
 					2D4167BC212C17AB005BB098 = {
 						CreatedOnToolsVersion = 9.4;
-						LastSwiftMigration = 0940;
+						LastSwiftMigration = 1010;
 					};
 					2D4167C5212C17AB005BB098 = {
 						CreatedOnToolsVersion = 9.4;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -447,6 +448,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -471,6 +473,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = be.AppFoundry.Direkt;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -493,6 +496,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = be.AppFoundry.DirektTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -515,6 +519,7 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = be.AppFoundry.DirektTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Direkt/BaseNavigationManager.swift
+++ b/Direkt/BaseNavigationManager.swift
@@ -16,13 +16,14 @@ open class BaseNavigationManager: NavigationManager {
         self.resolver = resolver
     }
 
-    open func navigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) {
+    open func navigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) throws {
         do {
             try resolver
                 .resolve(navigator)
-                .navigate(using: input, from: hostViewController, resolver: resolver)
+                .navigate(using: input, from: hostViewController, resolver: resolver, manager: self)
         } catch {
             didFailNavigation(to: navigator, error: error, hostViewController: hostViewController)
+            throw error
         }
     }
 

--- a/Direkt/NavigationManager.swift
+++ b/Direkt/NavigationManager.swift
@@ -10,12 +10,26 @@ import UIKit
 
 public protocol NavigationManager {
 
-    func navigate<T: Navigator>(to navigator: T.Type, using: T.Input, from hostViewController: UIViewController)
+    func navigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) throws
 }
 
 public extension NavigationManager {
 
-    func navigate<T: Navigator>(to navigator: T.Type, from hostViewController: UIViewController) where T.Input == Void {
-        navigate(to: navigator, using: (), from: hostViewController)
+    func navigate<T: Navigator>(to navigator: T.Type, from hostViewController: UIViewController) throws where T.Input == Void {
+        try navigate(to: navigator, using: (), from: hostViewController)
+    }
+
+    ///
+    /// - Returns: false if navigation failed
+    @discardableResult
+    func attemptNavigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) -> Bool {
+        return (try? self.navigate(to: T.self, using: input, from: hostViewController)) != nil
+    }
+
+    ///
+    /// - Returns: false if navigation failed
+    @discardableResult
+    func attemptNavigate<T: Navigator>(to navigator: T.Type, from hostViewController: UIViewController) -> Bool where T.Input == Void {
+        return (try? navigate(to: navigator, using: (), from: hostViewController)) != nil
     }
 }

--- a/Direkt/Navigator.swift
+++ b/Direkt/Navigator.swift
@@ -12,5 +12,5 @@ public protocol Navigator {
 
     associatedtype Input
 
-    func navigate(using input: Input, from hostViewController: UIViewController, resolver: Resolver) throws
+    func navigate(using input: Input, from hostViewController: UIViewController, resolver: Resolver, manager: NavigationManager) throws
 }

--- a/DirektTests/NavigationStackMock.swift
+++ b/DirektTests/NavigationStackMock.swift
@@ -28,7 +28,7 @@ class MockNavigator<T>: MethodCallMock, Navigator {
 
     var calls: [MethodCall] = []
 
-    func navigate(using input: T, from hostViewController: UIViewController, resolver: Resolver) throws {
+    func navigate(using input: T, from hostViewController: UIViewController, resolver: Resolver, manager: NavigationManager) throws {
         _ = try resolver.resolve(MockViewController.self, input: input)
         makeCall(.navigate(input, hostViewController: hostViewController, resolver: resolver))
     }
@@ -107,9 +107,9 @@ class MockNavigationManager: BaseNavigationManager, MethodCallMock {
 
     var calls: [MockNavigationManager.MethodCall] = []
 
-    override func navigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) {
+    override func navigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) throws {
         makeCall(.navigate(navigator, input: input, hostViewController: hostViewController))
-        super.navigate(to: navigator, using: input, from: hostViewController)
+        try super.navigate(to: navigator, using: input, from: hostViewController)
     }
 
     override func didFailNavigation<T: Navigator>(to navigator: T.Type, error: Error, hostViewController: UIViewController) {

--- a/DirektTests/NavigatorTests.swift
+++ b/DirektTests/NavigatorTests.swift
@@ -41,7 +41,7 @@ class NavigationManagerSpec: QuickSpec {
                     expect { try resolver.resolve(MockNavigator<Int>.self) }
                         .to(throwError())
 
-                    manager.navigate(to: MockNavigator<Int>.self, using: 0, from: mockHost)
+                    manager.attemptNavigate(to: MockNavigator<Int>.self, using: 0, from: mockHost)
                     expect(
                         manager.didCall(
                             .didFailNavigation(
@@ -55,7 +55,7 @@ class NavigationManagerSpec: QuickSpec {
             }
 
             it("handles optional parameters") {
-                manager.navigate(to: MockNavigator<Void>.self, from: mockHost)
+                manager.attemptNavigate(to: MockNavigator<Void>.self, from: mockHost)
 
                 expect(
                     manager.didCall(
@@ -64,9 +64,21 @@ class NavigationManagerSpec: QuickSpec {
                 ).to(beTrue())
             }
 
+            context("navigation result") {
+                it("provides failed navigation error") {
+                    expect { try manager.navigate(to: MockNavigator<Double>.self, using: 0, from: mockHost) }
+                        .to(throwError(MockResolver.Error.unkownType(MockNavigator<String>.self)))
+                }
+
+                it("provides navigation result") {
+                    expect(manager.attemptNavigate(to: MockNavigator<Void>.self, from: mockHost)) == true
+                    expect(manager.attemptNavigate(to: MockNavigator<Double>.self, using: 0, from: mockHost)) == false
+                }
+            }
+
             context("performs navigation step") {
                 beforeEach {
-                    manager.navigate(to: MockNavigator<String>.self, using: "mock", from: mockHost)
+                    manager.attemptNavigate(to: MockNavigator<String>.self, using: "mock", from: mockHost)
                 }
 
                 it("resolves dependencies") {


### PR DESCRIPTION
I'd like to propose some API changes based on how we use Direkt.

* Simplify combining multiple navigators logic, by passing `NavigationManager` instance. So that one navigator can trigger others. Currently we are working around this by resolving manager through the `Resolver` 
* Catching error at *NavigationManager* could be useful for logging purposes etc., but we didn't use it for anything else. So I'd propose to make the `navigate` method throwing so that caller has immediate feedback on navigation result. This is also needed to make sure chaining navigators covers multiple cases.

**Note** This would be breaking current Direkt API, so we would have to release those changes in new major version.