### PR TITLE
feature/NavigationFeedback

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v7.1.3"
-github "Quick/Quick" "v1.3.1"
+github "Quick/Nimble" "v7.3.4"
+github "Quick/Quick" "v1.3.4"

--- a/Direkt.xcodeproj/project.pbxproj
+++ b/Direkt.xcodeproj/project.pbxproj
@@ -361,7 +361,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -419,7 +419,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Direkt/BaseNavigationManager.swift
+++ b/Direkt/BaseNavigationManager.swift
@@ -16,13 +16,18 @@ open class BaseNavigationManager: NavigationManager {
         self.resolver = resolver
     }
 
-    open func navigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) {
+    open func attemptNavigate<T: Navigator>(
+        to navigator: T.Type,
+        using input: T.Input,
+        from hostViewController: UIViewController
+    ) throws {
         do {
             try resolver
                 .resolve(navigator)
                 .navigate(using: input, from: hostViewController, resolver: resolver)
         } catch {
             didFailNavigation(to: navigator, error: error, hostViewController: hostViewController)
+            throw error
         }
     }
 

--- a/Direkt/NavigationManager.swift
+++ b/Direkt/NavigationManager.swift
@@ -10,12 +10,26 @@ import UIKit
 
 public protocol NavigationManager {
 
-    func navigate<T: Navigator>(to navigator: T.Type, using: T.Input, from hostViewController: UIViewController)
+    func attemptNavigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) throws
 }
 
 public extension NavigationManager {
 
-    func navigate<T: Navigator>(to navigator: T.Type, from hostViewController: UIViewController) where T.Input == Void {
-        navigate(to: navigator, using: (), from: hostViewController)
+    ///
+    /// - Returns: false if navigation failed
+    @discardableResult
+    func navigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) -> Bool {
+        return (try? attemptNavigate(to: T.self, using: input, from: hostViewController)) != nil
+    }
+
+    ///
+    /// - Returns: false if navigation failed
+    @discardableResult
+    func navigate<T: Navigator>(to navigator: T.Type, from hostViewController: UIViewController) -> Bool where T.Input == Void {
+        return navigate(to: T.self, using: (), from: hostViewController)
+    }
+
+    func attemptNavigate<T: Navigator>(to navigator: T.Type, from hostViewController: UIViewController) throws where T.Input== Void {
+        try attemptNavigate(to: T.self, using: (), from: hostViewController)
     }
 }

--- a/DirektTests/NavigationStackMock.swift
+++ b/DirektTests/NavigationStackMock.swift
@@ -86,12 +86,12 @@ class MockNavigationManager: BaseNavigationManager, MethodCallMock {
 
     enum MethodCall: Equatable {
 
-        case navigate(Any.Type, input: Any, hostViewController: UIViewController)
+        case attemptNavigate(Any.Type, input: Any, hostViewController: UIViewController)
         case didFailNavigation(Any.Type, Error, UIViewController)
 
         static func == (lhs: MethodCall, rhs: MethodCall) -> Bool {
             switch (lhs, rhs) {
-            case let (.navigate(lhs), .navigate(rhs)):
+            case let (.attemptNavigate(lhs), .attemptNavigate(rhs)):
                 return lhs.0 == rhs.0
                     && type(of: lhs.input) == type(of: rhs.input)
                     && lhs.hostViewController === rhs.hostViewController
@@ -107,9 +107,13 @@ class MockNavigationManager: BaseNavigationManager, MethodCallMock {
 
     var calls: [MockNavigationManager.MethodCall] = []
 
-    override func navigate<T: Navigator>(to navigator: T.Type, using input: T.Input, from hostViewController: UIViewController) {
-        makeCall(.navigate(navigator, input: input, hostViewController: hostViewController))
-        super.navigate(to: navigator, using: input, from: hostViewController)
+    override func attemptNavigate<T: Navigator>(
+        to navigator: T.Type,
+        using input: T.Input,
+        from hostViewController: UIViewController
+    ) throws {
+        makeCall(.attemptNavigate(navigator, input: input, hostViewController: hostViewController))
+        try super.attemptNavigate(to: navigator, using: input, from: hostViewController)
     }
 
     override func didFailNavigation<T: Navigator>(to navigator: T.Type, error: Error, hostViewController: UIViewController) {

--- a/DirektTests/NavigatorTests.swift
+++ b/DirektTests/NavigatorTests.swift
@@ -59,9 +59,31 @@ class NavigationManagerSpec: QuickSpec {
 
                 expect(
                     manager.didCall(
-                        .navigate(MockNavigator<Void>.self, input: (), hostViewController: mockHost)
+                        .attemptNavigate(MockNavigator<Void>.self, input: (), hostViewController: mockHost)
                     )
                 ).to(beTrue())
+            }
+
+            it("handles optional parameters with failable navigation") {
+                try? manager.attemptNavigate(to: MockNavigator<Void>.self, from: mockHost)
+
+                expect(
+                    manager.didCall(
+                        .attemptNavigate(MockNavigator<Void>.self, input: (), hostViewController: mockHost)
+                    )
+                ).to(beTrue())
+            }
+
+            context("navigation result") {
+                it("provides failed navigation error") {
+                    expect { try manager.attemptNavigate(to: MockNavigator<Double>.self, using: 0, from: mockHost) }
+                        .to(throwError(MockResolver.Error.unkownType(MockNavigator<String>.self)))
+                }
+
+                it("provides navigation result") {
+                    expect(manager.navigate(to: MockNavigator<Void>.self, from: mockHost)) == true
+                    expect(manager.navigate(to: MockNavigator<Double>.self, using: 0, from: mockHost)) == false
+                }
             }
 
             context("performs navigation step") {
@@ -86,7 +108,7 @@ class NavigationManagerSpec: QuickSpec {
                 it("calls navigation methods") {
                     expect(
                         manager.didCall(
-                            .navigate(MockNavigator<String>.self, input: "mock", hostViewController: mockHost)
+                            .attemptNavigate(MockNavigator<String>.self, input: "mock", hostViewController: mockHost)
                         )
                     ).to(beTrue())
 


### PR DESCRIPTION
Following `Direkt` discussion, I extracted navigation failure feedback from #1.
Also I've changed API slightly comparing to #1, so that now we have no breaking changes. 
If user wants to use `throwable` version they have to explicitly use `attemptNavigate` method.
`navigate` returns simple bool value, but is annotated with `discardableResult`, thus won't introduce any warnings in existing codebases.